### PR TITLE
DL method: allow flexibility using N,E in place of 1,2 for land stations

### DIFF
--- a/orientpy/utils.py
+++ b/orientpy/utils.py
@@ -481,8 +481,12 @@ def DLcalc(stream, Rf, LPF, HPF, epi, baz, A, winlen=10., ptype=0):
     st = stream.slice(starttime=dt+r1, endtime=dt+r2)
 
     # Extract waveform data for each component
-    tr1 = st.select(component='1')[0].data
-    tr2 = st.select(component='2')[0].data
+    try:
+        tr1 = st.select(component='1')[0].data
+        tr2 = st.select(component='2')[0].data
+    except:
+        tr1 = st.select(component='N')[0].data
+        tr2 = st.select(component='E')[0].data
     trZ = st.select(component='Z')[0].data
 
     # Calculate Hilbert transform of vertical trace data


### PR DESCRIPTION
Will check first for components 1,2 and otherwise will use N,E. Tested on the PLUME dataset (network code YS), which includes both OBS and land stations. The BNG method had no problem using the N,E components.